### PR TITLE
feat: Docker compose with minio client.

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -1,26 +1,38 @@
 # Containers Stak
-STACK_NAME="adempiere-s3-gateway-service"
+COMPOSE_PROJECT_NAME="adempiere-s3-service"
+STACK_NAME="${COMPOSE_PROJECT_NAME}"
 
 ## Generic Restart
 GENERIC_RESTART="always"
 
-# S3
-S3_IMAGE="quay.io/minio/minio"
-S3_HOST="${STACK_NAME}.s3"
-S3_PORT=9000
-S3_CONSOLE_PORT=9090
-S3_USER=adempiere
-S3_PASSWORD=adempiere
-S3_VOLUME="${STACK_NAME}.volume_s3"
-
-S3_GATEWAY_RS_HOST="default-stack.s3.gateway.rs"
-S3_GATEWAY_RS_IMAGE="openls/s3-gateway-rs:1.0.1"
-S3_GATEWAY_RS_PORT="7878"
-# Values
-S3_GATEWAY_RS_S3_URL="http://s3.service:9000"
-S3_GATEWAY_RS_BUCKET_NAME="-" # Fill It
-S3_GATEWAY_RS_API_KEY="-" # Fill It
-S3_GATEWAY_RS_SECRET_KEY="-" # Fill It
-
 # Networks
 DEFAULT_NETWORK="default-stack.adempiere_network"
+
+
+# S3 Minio Storage
+S3_IMAGE="quay.io/minio/minio:RELEASE.2024-01-31T20-20-33Z"
+S3_HOST="${STACK_NAME}.s3"
+S3_PORT=9000
+S3_CONSOLE_INTERNAL_PORT=9090 # UI Management
+S3_CONSOLE_PORT=${S3_CONSOLE_INTERNAL_PORT} # UI Management
+S3_USER="adempiere"
+S3_PASSWORD="adempiere"
+S3_BUCKET_NAME="adempiere"
+S3_VOLUME="${STACK_NAME}.volume_s3"
+
+# S3 Minio Client
+S3_CLIENT_IMAGE="minio/mc:RELEASE.2024-01-31T08-59-40Z"
+S3_CLIENT_HOST="${STACK_NAME}.s3.client"
+S3_CLIENT_ACCESS_KEY="${S3_USER}"
+S3_CLIENT_SECRET_KEY="${S3_PASSWORD}"
+S3_CLIENT_BUCKET_NAME="S{S3_BUCKET_NAME}"
+
+
+# S3 Gateway RS
+S3_GATEWAY_RS_IMAGE="openls/s3-gateway-rs:1.0.1"
+S3_GATEWAY_RS_HOST="${STACK_NAME}.gateway.rs"
+S3_GATEWAY_RS_PORT=7878
+S3_GATEWAY_RS_S3_URL="http://s3.service:9000"
+S3_GATEWAY_RS_API_KEY="${S3_ACCESS_KEY}"
+S3_GATEWAY_RS_SECRET_KEY="${S3_SECRET_KEY}"
+S3_GATEWAY_RS_BUCKET_NAME="S{S3_BUCKET_NAME}"

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -4,10 +4,52 @@ name: services-s3-gateway
 
 services:
 
+  s3.service:
+    image: ${S3_IMAGE}
+    container_name: ${S3_HOST}
+    restart: ${GENERIC_RESTART}
+    command:
+      - "server"
+      - "/data"
+      - "--console-address=:${S3_CONSOLE_INTERNAL_PORT}"
+    healthcheck:
+      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/9000; exit $?;'"
+      interval: 10s
+      retries: 60
+      start_period: 20s
+      timeout: 10s
+    environment:
+      MINIO_ROOT_USER: ${S3_USER}
+      MINIO_ROOT_PASSWORD: ${S3_PASSWORD}
+    ports:
+      - ${S3_PORT}:9000
+      - ${S3_CONSOLE_PORT}:${S3_CONSOLE_INTERNAL_PORT}
+    networks:
+      - shared_network
+    volumes:
+      - volume_s3:/data
+
+  s3.client:
+    image: ${S3_CLIENT_IMAGE}
+    container_name: ${S3_CLIENT_HOST}
+    depends_on:
+      s3.service:
+        condition: service_healthy
+    entrypoint: /bin/sh -c
+    command: |
+      sleep 5
+      mc config host add local http://s3.service:9000 ${S3_CLIENT_ACCESS_KEY} ${S3_CLIENT_SECRET_KEY}
+      mc --insecure mb local/${S3_CLIENT_BUCKET_NAME}
+    networks:
+      - shared_network
+
   s3.gateway.service:
     image: ${S3_GATEWAY_RS_IMAGE}
     container_name: ${S3_GATEWAY_RS_HOST}
     restart: ${GENERIC_RESTART}
+    depends_on:
+      s3.service:
+        condition: service_healthy
     environment:
       S3_URL: ${S3_GATEWAY_RS_S3_URL}
       BUCKET_NAME: ${S3_GATEWAY_RS_BUCKET_NAME}
@@ -17,30 +59,13 @@ services:
       - ${S3_GATEWAY_RS_PORT}:7878
     networks:
       - shared_network
-  
-  s3.service:
-    image: ${S3_IMAGE}
-    container_name: ${S3_HOST}
-    restart: ${GENERIC_RESTART}
-    ports:
-      - ${S3_PORT}:9000
-      - ${S3_CONSOLE_PORT}:9090
-    command:
-      - "server"
-      - "/data"
-      - "--console-address=:9090"
-    environment:
-      MINIO_ROOT_USER: ${S3_USER}
-      MINIO_ROOT_PASSWORD: ${S3_PASSWORD}
-    volumes:
-      - volume_s3:/data
-    networks:
-      - shared_network
+
 
 networks:
   shared_network:
     name: ${DEFAULT_NETWORK}
-     
+
+
 volumes:
   volume_s3:
     name: ${S3_VOLUME}


### PR DESCRIPTION
- Add minio client to create bocket and keys.
- Add `COMPOSE_PROJECT_NAME` env.
- Parametizer `S3_CONSOLE_PORT`.
- Add service dependeds container.